### PR TITLE
use rev in git dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "imgui_baseview_test_vst2"
 crate-type = ["cdylib"]
 
 [dependencies]
-baseview = {git = "https://github.com/RustAudio/baseview", branch = "master"}
+baseview = {git = "https://github.com/RustAudio/baseview", rev = "d399c1275522ae75f5a82caadd904df2685c8660" }
 dirs = "3"
 log = "0.4"
 log-panics = "2"
@@ -18,5 +18,5 @@ raw-window-handle = "0.3"
 simplelog = "0.8"
 vst = "0.2"
 rtrb = "0.1.1"
-imgui-baseview = {git = "https://github.com/BillyDM/imgui-baseview", branch = "main"}
+imgui-baseview = {git = "https://github.com/BillyDM/imgui-baseview", rev = "3ea419f53727a39d36a0c2e0767f6873a23bf0e9" }
 imgui = "0.7"


### PR DESCRIPTION
* Use revisions in git dependencies to avoid any future breaking changes